### PR TITLE
Bug fix for get_foxsi_image.pro

### DIFF
--- a/idl/response/get_foxsi_image.pro
+++ b/idl/response/get_foxsi_image.pro
@@ -116,9 +116,9 @@ FOR i = 0.0, N_ELEMENTS(source_map.data)-1 DO BEGIN
         ENDELSE
 
         IF y_size/2 - y GT 0 THEN BEGIN
-           shifted_convolved_pixel[psf_y_size-(y_size/2 - y):*,0:*] = 0
+           shifted_convolved_pixel[0:*,psf_y_size-(y_size/2 - y):*] = 0
         ENDIF ELSE BEGIN
-           shifted_convolved_pixel[0:y-y_size/2-1,0:*] = 0
+           shifted_convolved_pixel[0:*,0:y-y_size/2-1] = 0
         ENDELSE
 
        shifted_convolved_pixel = shifted_convolved_pixel[(psf_x_size-x_size)/2:(psf_x_size+x_size)/2-1, (psf_x_size-x_size)/2:(psf_y_size+y_size)/2-1]


### PR DESCRIPTION
While trying to use get_foxsi_image, I was encountering out of range subscript errors. On closer inspection, it looks like shifted_convolved_pixel was being indexed the wrong way round on line 119 and 121. The y values are being used to index x.

You wouldn't get an error when using a square map, but I had used a non-square map as the input. After changing these lines I was able to get the routine to operate normally, and the results looked consistent with the images I had made just using the IDL CONVOL function.

Ping @LinErinG @samuel-badman - does this look right?
