### PR TITLE
Quick bug fix for scaling the optics effective area

### DIFF
--- a/pyfoxsi/src/pyfoxsi/response/response.py
+++ b/pyfoxsi/src/pyfoxsi/response/response.py
@@ -76,7 +76,7 @@ class Response(object):
 
     @number_of_telescopes.setter
     def number_of_telescopes(self, x):
-        self.effective_area['total'] = self.effective_area['total'] / self.__number_of_telescopes * x
+        self.optics_effective_area['total'] = self.optics_effective_area['total'] / self.__number_of_telescopes * x
         self.__number_of_telescopes = x
 
     @property


### PR DESCRIPTION
Bad, @ehsteve, for merging #10 before a final check!  Here's the bug fix so that the optics effective area is multiplied by the number of telescopes.
