### PR TITLE
Fix to Sphinx configuration for RTD

### DIFF
--- a/pyfoxsi/doc/source/conf.py
+++ b/pyfoxsi/doc/source/conf.py
@@ -20,7 +20,7 @@ import warnings
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath("../../"))
+sys.path.insert(0, os.path.abspath("../../src/"))
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -31,12 +31,14 @@ sys.path.insert(0, os.path.abspath("../../"))
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
+    'numpydoc',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
The path needs the `src/` so that RTD can find the (non-installed) code.

Other hooks being used need `numpydoc`.  This will lead to a whole bunch of warnings in the Sphinx output, which can be ignored.
