### PR TITLE
Adding more options for user provided spectral information and adding counting statistics.

### DIFF
--- a/idl/docs/imaging.md
+++ b/idl/docs/imaging.md
@@ -21,7 +21,9 @@ This function is intended to simulate the image measured by the FOXSI detectors 
 given input source image without spectral information.This must be a 2D monochromatic source.
 
 This involves modelling the convolution of the image due to the point spread function of
-the optics modules and the pixelisation of the detectors. The function may be run with an
+the optics modules and the pixelisation of the detectors followed by accounting for counting
+statistics by replacing each pixels value with a randomly selected value from a poisson 
+distribution with a mean set by the original value of that pixel. The function may be run with an
 automatically generated source (two narrow gaussians near the centre of a 150x150 FOV)
 and a default pixelisation of 3'' per pixel with the call:
 
@@ -67,7 +69,7 @@ foxsi_get_output_image_cube.pro                       (located in /response fold
 This function is intended to simulate the image measured by the FOXSI detectors for a
 given input source with spectral information.
 
-For each energy slice, all bins are multiplied by an effective area obtained from the function foxsi_get_effective_area and interpolated to match the energy value of the input source slice. This slice is then processed identically to the monochromatic case described above under foxsi_get_default_2d_image.pro.
+For each energy slice, each pixels flux (integrated in time) is multiplied by an effective area obtained from the function foxsi_get_effective_area and interpolated to match the energy value of the input source slice. This slice is then processed identically to the monochromatic case described above under foxsi_get_default_2d_image.pro.
 
 The function may be called with a default spectral cube and default pixelisation ( 3'' per pixel). 
 

--- a/idl/response/foxsi_get_output_2d_image.pro
+++ b/idl/response/foxsi_get_output_2d_image.pro
@@ -11,7 +11,12 @@
 ;;;               solar coordinates of the image sensor. After
 ;;;               convolution, the new image is rebinned according to
 ;;;               the keyword px = pix_size (default = 3) to reflect the
-;;;               loss of resolution due to the finite strip size in the detectors.
+;;;               loss of resolution due to the finite strip size in
+;;;               the detectors. Finally, counting statistics is
+;;;               accounted for via replacing each pixel's value with
+;;;               one randomly drawn from a poisson distribution
+;;;               with a mean given by that pixel's original value.
+;;;               
 ;;; 
 ;;;
 ;;;CALL SEQUENCE: rebinned_convolved_map = foxsi_get_output_2d_image()

--- a/idl/response/foxsi_get_output_2d_image.pro
+++ b/idl/response/foxsi_get_output_2d_image.pro
@@ -27,7 +27,9 @@
 ;;;               function
 ;;;
 ;;;               px = "pixel size of detector" in arcseconds, default is 3''
-;;;
+;;;               
+;;;               no_count_stats - if keyword set no counting stats
+;;;                                accounted for
 ;;;
 ;;;COMMENTS:      -Runtime scales badly with FOV size
 ;;;               -The default source array is 
@@ -39,7 +41,7 @@
 ;;;                detectable at low resolutions.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-FUNCTION foxsi_get_output_2d_image,source_map = source_map, px = pix_size
+FUNCTION foxsi_get_output_2d_image,source_map = source_map, px = pix_size, no_count_stats = no_count_stats
 
 IF N_ELEMENTS(SOURCE_MAP) EQ 0 THEN PRINT, 'No user input detected, using default source image'
 
@@ -153,16 +155,18 @@ rebinned_convolved_map = make_map(rebinned_convolved_array, dx = pix_size, dy = 
 output_dims = SIZE(rebinned_convolved_map.data,/DIM)
 
 ;;;; Add noise due to counting statistics for each pixel ;;;;;
-FOR x = 0, output_dims[0] - 1 DO BEGIN
-   FOR y = 0, output_dims[1] - 1 DO BEGIN
+IF KEYWORD_SET(no_count_stats) NE 1 THEN BEGIN
+  FOR x = 0, output_dims[0] - 1 DO BEGIN
+     FOR y = 0, output_dims[1] - 1 DO BEGIN
           mean = rebinned_convolved_map.data[x,y]
           IF mean NE 0.0 THEN BEGIN 
                   noisy_value = RANDOMU(seed, 1, POISSON = mean)
                   rebinned_convolved_map.data[x,y] = noisy_value
                ENDIF         
       
-   ENDFOR
-ENDFOR
+     ENDFOR
+  ENDFOR
+ENDIF
 
 print,  'rebinned_convolved_map returned'
 

--- a/idl/response/foxsi_get_output_2d_image.pro
+++ b/idl/response/foxsi_get_output_2d_image.pro
@@ -145,6 +145,20 @@ rebinned_convolved_map = make_map(rebinned_convolved_array, dx = pix_size, dy = 
                          xc = source_map.xc, yc = source_map.yc, id = STRCOMPRESS(          $
                          'Rebinned_Convolved_Map_Pixel_Size:'+string(pix_size),/REMOVE_AL))
 
+output_dims = SIZE(rebinned_convolved_map.data,/DIM)
+
+;;;; Add noise due to counting statistics for each pixel ;;;;;
+FOR x = 0, output_dims[0] - 1 DO BEGIN
+   FOR y = 0, output_dims[1] - 1 DO BEGIN
+          mean = rebinned_convolved_map.data[x,y]
+          IF mean NE 0.0 THEN BEGIN 
+                  noisy_value = RANDOMU(seed, 1, POISSON = mean)
+                  rebinned_convolved_map.data[x,y] = noisy_value
+               ENDIF         
+      
+   ENDFOR
+ENDFOR
+
 print,  'rebinned_convolved_map returned'
 
 RETURN, rebinned_convolved_map

--- a/idl/response/foxsi_get_output_image_cube.pro
+++ b/idl/response/foxsi_get_output_image_cube.pro
@@ -427,6 +427,21 @@ FOR rebin_layer = 0.0, N_ELEMENTS(rebinned_convolved_cube[0,0,*])-1 DO BEGIN
     output_map_cube[rebin_layer] = rebinned_convolved_slice
 
 
+ ENDFOR
+
+output_dims = SIZE(output_map_cube.data, /DIM)
+
+;;;; Add noise due to counting statistics for each pixel ;;;;;
+FOR x = 0, output_dims[0] - 1 DO BEGIN
+   FOR y = 0, output_dims[1] - 1 DO BEGIN
+      FOR z = 0, output_dims[2] - 1 DO BEGIN
+          mean = output_map_cube[z].data[x,y]
+          IF mean NE 0.0 THEN BEGIN 
+                  noisy_value = RANDOMU(seed, 1, POISSON = mean)
+                  output_map_cube[z].data[x,y] = noisy_value
+               ENDIF         
+       ENDFOR
+   ENDFOR
 ENDFOR
 
 print,  'output_map_cube returned'

--- a/idl/response/foxsi_get_output_image_cube.pro
+++ b/idl/response/foxsi_get_output_image_cube.pro
@@ -19,7 +19,11 @@
 ;;;               convolution, the new image is rebinned according to
 ;;;               the keyword px = pix_size (default = 3) to reflect
 ;;;               the loss of resolution due to the finite strip size
-;;;               in the detectors.The output is a structure
+;;;               in the detectors. Finally, counting statistics based
+;;;               is accounted for by randomising each pixel's
+;;;               value with a poisson distribution with a mean given
+;;;               by the pixel's original value.
+;;;               The output is a structure
 ;;;               containing  imaged maps at the inputted energy with
 ;;;               appended tags specifying the energy bin range for
 ;;;               each map. 

--- a/idl/response/foxsi_make_source_structure.pro
+++ b/idl/response/foxsi_make_source_structure.pro
@@ -4,21 +4,30 @@
 ;;; HISTORY:        Initial Commit - 09/08/15 - Samuel Badman
 ;;;
 ;;; DESCRIPTION:    Takes user inputted source map cube and spectral
-;;;                 min and max and converts this to the required
+;;;                 information and converts this to the required
 ;;;                 structure for the function
 ;;;                 foxsi_get_output_image_cube.
+;;;                 Takes either a max and min energy value of the
+;;;                 whole energy range and interpolates evenly spaced
+;;;                 bin widths or takes an array of bin edges of
+;;;                 dimension: map_cube energy dim - 1 and labels the
+;;;                 cube with these.     
 ;;;
-;;; CALL SEQUENCE:  source_map_spectrum =                          $
-;;;                 foxsi_make_source_structure('input_map_cube',  $
-;;;                 'lower_energy_bound','upper energy bound')
+;;; CALL SEQUENCE:  source_map_spectrum = foxsi_make_source_structure('input_map_cube')
 ;;;
+;;; KEYWORDS:       e_min = 'lower energy bound of lowest energy bin'
+;;;                 e_max = 'upper energy bound of highest energy bin'
+;;;                 arr = 'array of energy bin boundaries'
+;;;
+;;; 
 ;;; COMMENTS:      lower and upper energy bounds are the lowest energy
 ;;;                value in the lowest energy bin and the highest energy in the
 ;;;                highest energy bin respectively
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
-FUNCTION str_test, source_map_spectrum, e_min = e_min,e_max = e_max, arr = arr
+FUNCTION foxsi_make_source_structure, source_map_spectrum, e_min = e_min,  $
+                                      e_max = e_max, arr = arr
 
 
 spec_size = N_ELEMENTS(source_map_spectrum.data[0,0,*])

--- a/idl/response/foxsi_make_source_structure.pro
+++ b/idl/response/foxsi_make_source_structure.pro
@@ -1,49 +1,70 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; FUNCTION: "foxsi_make_source_structure"
+;;; FUNCTION:       "foxsi_make_source_structure"
 ;;;
-;;; HISTORY: Initial Commit - 09/08/15 - Samuel Badman
+;;; HISTORY:        Initial Commit - 09/08/15 - Samuel Badman
 ;;;
-;;; DESCRIPTION: Takes user inputted source map cube and spectral
-;;;              min and max and converts this to the required
-;;;              structure for the function
-;;;              foxsi_get_output_image_cube.
+;;; DESCRIPTION:    Takes user inputted source map cube and spectral
+;;;                 min and max and converts this to the required
+;;;                 structure for the function
+;;;                 foxsi_get_output_image_cube.
 ;;;
-;;; CALL SEQUENCE: source_map_spectrum = $
-;;;                foxsi_make_source_structure('input_map_cube', $
-;;;                'lower_energy_bound','upper energy bound')
+;;; CALL SEQUENCE:  source_map_spectrum =                          $
+;;;                 foxsi_make_source_structure('input_map_cube',  $
+;;;                 'lower_energy_bound','upper energy bound')
 ;;;
-;;; COMMENTS: lower and upper energy bounds are the lowest energy
-;;; value in the lowest energy bin and the highest energy in the
-;;; highest energy bin respectively
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; COMMENTS:      lower and upper energy bounds are the lowest energy
+;;;                value in the lowest energy bin and the highest energy in the
+;;;                highest energy bin respectively
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-FUNCTION foxsi_make_source_structure, source_map_spectrum, e_min, e_max
+
+FUNCTION str_test, source_map_spectrum, e_min = e_min,e_max = e_max, arr = arr
+
 
 spec_size = N_ELEMENTS(source_map_spectrum.data[0,0,*])
-
 source_data_cube = source_map_spectrum
 
-source_cube_creator = ADD_TAG(ADD_TAG(source_map_spectrum[0], 0.0, $
-                               'energy_bin_lower_bound_keV') ,0.0, $
-                               'energy_bin_upper_bound_kev')
+source_cube_creator = ADD_TAG(ADD_TAG(source_map_spectrum[0], 0.0,       $ 
+                      'energy_bin_lower_bound_keV') ,0.0,                $
+                      'energy_bin_upper_bound_kev')
 
 source_map_spectrum = REPLICATE(source_cube_creator, spec_size)
 
-energy_spacings = FINDGEN(spec_size+1)*(e_max - e_min)/spec_size
+IF KEYWORD_SET(arr) EQ 0 THEN BEGIN
 
-lower_bound_array = energy_spacings[0:spec_size-1] + e_min
+   energy_spacings = FINDGEN(spec_size + 1)*(e_max - e_min)/(spec_size) 
+   lower_bound_array = energy_spacings[0:spec_size-1] + e_min
+   upper_bound_array = energy_spacings[1:*] + e_min
 
-upper_bound_array = energy_spacings[1:*] + e_min
+ENDIF ELSE BEGIN
+              
+              arr = FLOAT(arr)               
+
+              IF spec_size NE N_ELEMENTS(arr) - 1 THEN BEGIN 
+                 
+                 PRINT, 'Bin edges array does not match up to energy dimension of the data cube'
+             
+              ENDIF
+  
+              lower_bound_array = arr[0:spec_size - 1]
+              upper_bound_array = arr[1:*]
+
+           ENDELSE
 
 FOR i = 0, spec_size - 1 DO BEGIN
 
+   
    ;;; Adding tags to the structure to keep track of min/max energy of
    ;;; each spectral bin
+
    source_map = ADD_TAG(source_data_cube[i], lower_bound_array[i],'energy_bin_lower_bound_keV')
    source_map = ADD_TAG(source_map, upper_bound_array[i],'energy_bin_upper_bound_keV')
+
    source_map_spectrum[i] = source_map
 
 ENDFOR
 
 RETURN, source_map_spectrum
+
 END
+

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+test content

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-test content


### PR DESCRIPTION
Two new features:

-Users are now able to specify either the max and min energy values of the highest energy bin  and lowest energy bins respectively in their data or provide an explicit array with energy bin boundary values (with dimensions equal to the height of their data cube + 1). There are also defaults in place in case neither of these are provided and the programme outputs text warnings that these parameters are missing.

-Counting statistics in each pixel are now accounted for in order to hopefully produce more realistic images. This is done by replacing each pixel in the final data cube with a value drawn pseudorandomly (from the idl RANDOMU routine) from a poisson distribution with a mean given by the number of counts in that pixel.
