### PR TITLE
Added to documentation on imaging and spectral response.

### DIFF
--- a/idl/README.md
+++ b/idl/README.md
@@ -17,4 +17,4 @@ the code.
 
 Documentation
 -------------
-All documentation can be found in the /docs folder.
+All documentation, including examples and walk-throughs, can be found in the /docs folder.

--- a/idl/docs/effective_area.md
+++ b/idl/docs/effective_area.md
@@ -1,6 +1,0 @@
-Effective Area
-==============
-
-The main function to access the effective area is `foxsi_get_effective_area`.
-It returns the effective area in cm^2 which includes the thermal blankets,
-detector efficiency, and shutters (if specificed).

--- a/idl/docs/imaging.md
+++ b/idl/docs/imaging.md
@@ -35,6 +35,7 @@ Alternatively, a user supplied source_map may be supplied and/or the function ru
 custom pixelization (example 1") as follows:
 
     IDL> out_map = foxsi_get_2d_image(source_map, px = 1)
+    IDL> plot_map, out_map
 
 The source_map can be any plot_map structure containing the source to be simulated. 
 Any pixelization can be used for the source; this information will be gleaned from the 

--- a/idl/docs/imaging.md
+++ b/idl/docs/imaging.md
@@ -1,7 +1,7 @@
 Imaging
 =======
 
-To get started, remember to work in your foxsi-smex/idl directory and on startup run the script 
+To get started, from your foxsi-smex/idl directory run the script 
 
         IDL> @foxsi-smex-setup-script.pro
 
@@ -13,104 +13,123 @@ Main Functions:
 
 
 foxsi_get_output_2d_image.pro                       (located in /response folder)
--------------------
+-----------------------------
 
 >> Requires make_map and plot_map functions.
 
 This function is intended to simulate the image measured by the FOXSI detectors for a
-given input source image without spectral information.This must be a 2D monochromatic source.
+given input source without regard to photon energy, i.e. a 2D monochromatic source.
+The function convolves the source map with the point spread function of the FOXSI optics.
+It then rebins the image to the pixelization of the detectors.  Random statistical 
+fluctuations are added by varying the value in each pixel using the Poisson uncertainties. 
+The addition of random statistics can be turned off by the keyword /NO_COUNT_STATS. 
+The default pixel size is 3" but can be set by the keyword PX.
 
-This involves modelling the convolution of the image due to the point spread function of
-the optics modules and the pixelisation of the detectors followed by accounting for counting
-statistics by replacing each pixels value with a randomly selected value from a poisson 
-distribution with a mean set by the original value of that pixel. The function may be run with an
-automatically generated source (two narrow gaussians near the centre of a 150x150 FOV)
-and a default pixelisation of 3'' per pixel with the call:
+The function may be run with an automatically generated source (two narrow gaussians 
+near the centre of a 150"x150" FOV) and a default pixelisation of 3" with the call:
 
-    IDL> rebinned_convolved_map = foxsi_get_2d_image()
+    IDL> out_map = foxsi_get_output_2d_image()
+    IDL> plot_map, out_map
 
-And the output viewed with the command:
+Alternatively, a user supplied source_map may be supplied and/or the function run with a
+custom pixelization (example 1") as follows:
 
-    IDL> plot_map, rebinned_convolved_map
+    IDL> out_map = foxsi_get_2d_image(source_map, px = 1)
 
-Alternatively, a user supplied source_map may be supplied and the function run with a
-custom pixelisation as follows:
+The source_map can be any plot_map structure containing the source to be simulated. 
+Any pixelization can be used for the source; this information will be gleaned from the 
+plot_map structure.  The keyword PX is the pixelization for the detector only. 
 
-    IDL> rebinned_convolved_map = foxsi_get_2d_image(source_map, px = "Your Pixelisation Value")
-
-Note the source_map file contains information on the pixel size in arcseconds and the solar
-coordinates of the centre of the field of view. This is automatically read in and propagated
-in the programme.
-
-The convolution currently only has one point spread function which was obtained from measuring
-the point spread function for the on-axis position (<< note, currently off axis measurement used,
-waiting for on axis fitting parameters >>) and fitting this with three gaussians. (See the preamble
-of get_psf_array.pro for details). Future iterations of this code will include some functionality
-to include variance in the psf for a given off axis source position and also for convolving at
-different spatial points in the optics cross section.
+The convolution currently only has one point spread function which was obtained from 
+measuring the point spread function for the on-axis position and fitting this with 
+three gaussians. (See the preamble of get_psf_map.pro for details).
 
 
 WARNING: Run time is dependent on the size of the FOV. The default FOV is 150x150 pixels,
 or 2.5'x2.5', this runs in a few seconds. Simulating the entire FOXSI FOV (~16.5'x16.5')
-will take ~9 Hours.
+will take ~10 minutes.
 
 
 Peripheral Functions:
-- foxsi_get_source_map.pro                      (located in /response folder)
-- foxsi_get_psf_array.pro                       (located in /response folder)
+- foxsi_get_default_source_map.pro            (located in /response folder)
+- foxsi_get_psf_map.pro                       (located in /response folder)
 
 
 
 foxsi_get_output_image_cube.pro                       (located in /response folder)
--------------------
+-------------------------------
 
->> Requires make_map,plot_map, add_tag functions.
+>> Requires MAKE_MAP, PLOT_MAP, ADD_TAG functions.
 
-This function is intended to simulate the image measured by the FOXSI detectors for a
-given input source with spectral information.
+This function simulates imaging spectroscopy for the FOXSI optics/detectors for a
+given input source that includes energy information.  The input source should be a 
+plot_map array with each array element containing the source image in a particular 
+energy bin.  The energies must be designated in the structure using the tags 
+ENERGY_BIN_LOWER_BOUND_KEV and ENERGY_BIN_UPPER_BOUND_KEV.  The function 
+FOXSI_MAKE_SOURCE_STRUCTURE can be used to add these tags, or the requisite info can 
+be passed to the main function.
 
-For each energy slice, each pixels flux (integrated in time) is multiplied by an effective area obtained from the function foxsi_get_effective_area and interpolated to match the energy value of the input source slice. This slice is then processed identically to the monochromatic case described above under foxsi_get_default_2d_image.pro.
+It is assumed that values in the source map are in units of photons/cm2.
 
-The function may be called with a default spectral cube and default pixelisation ( 3'' per pixel). 
+For each map, the source fluxes are multiplied by the effective area obtained from the 
+function FOXSI_GET_EFFECTIVE_AREA and interpolated to match the energy bins of the input 
+source.  Each map is then processed identically to the monochromatic case described above 
+under foxsi_get_output_2d_image.pro.
 
-    IDL> rebinned_convolved_maps = foxsi_get_spectral_image()
+The function may be called with a default source (containing image and spectral info) by:
 
-The default cube is generated by the peripheral function foxsi_get_default_source_cube.pro. This is a stack of 100x100 flux maps with energies from 1.0 to 60.0 KeV with each slice 2.0 KeV apart. The sources present are two gaussians either side of the centre of the FOV. The left one has a constant energy profile while the other decays exponentially.
+    IDL> out_maps = foxsi_get_output_image_cube()
+    IDL> plot_map, out_map
+
+The default source is generated by the peripheral function 
+FOXSI_GET_DEFAULT_SOURCE_CUBE.PRO. This is a stack of 100"x100" flux maps with energies 
+from 1.0 to 60.0 KeV in 2 keV bins.  The sources are two gaussians placed 50" apart 
+with different spectra (constant in energy for one, decaying exponentially with energy 
+for the other).
 
 To run the code with your own source data, please provide:
 
-  >> An array of 2d maps at evenly spaced energies (to be discussed)
-  >> The energy value of the lower bound of the lowest energy bin of your data 
-  >> The energy value of the upper bound of the highest energy bin of your data
+  >> An array of 2d maps using keyword SOURCE_MAP_SPECTRUM
 
-Then run the code with the line
+and one of these two options:
 
-    IDL> rebinned_convolved_maps = get_foxsi_output_image_cube("your_source_cube",bin_min =   $
-    'Lowest energy bound', bin_max = 'Highest energy bound', px = "Your Pixelisation Value")
+  (Option 1)
+  >> The lower edge of the lowest energy bin, using keyword E_MIN
+  >> The upper edge of the highest energy bin, using keyword E_MAX
+	In this usage, the energy array is assumed evenly spaced between these values.
+  	 
+  (Option 2)
+  >> An array of the energy bin edges using keyword BIN_EDGES_ARRAY.  In this usage, 
+		 any array of energies can be used.
 
-The code then assigns each energy slice a corresponding upper and lower energy value assuming a constant bin size across the spectrum. This is done with the peripheral function foxsi_make_source_structure.pro and uses the add_tag function.
+The following example creates a 2D Gaussian source and uses energy bins from 3-40 keV.)
 
-The output is an array of structures as above, each slice may be viewed with:
-
-    IDL>  plot_map, rebinned_convolved_maps[i]
-
-While the spectra for a given pixel (x,y) may be plotted against the midpoint energy of each bin with the line:
-
-    IDL> plot, (rebinned_convolved_maps.bin_min + rebinned_convolved_maps.bin_max)/2, $ rebinned_convolved_maps.data[x,y,*]
-
-Note: The convolution currently only has one point spread function which was obtained from measuring
-the point spread function for the on-axis position (<< note, currently off axis measurement used,
-waiting for on axis fitting parameters >>) and fitting this with three gaussians. (See the preamble
-of get_psf_array.pro for details). Future iterations of this code will include some functionality
-to include variance in the psf for a given off axis source position and also for convolving at
-different spatial points in the optics cross section.
+		IDL> src = make_map( psf_gaussian(fwhm=2, npixel=100) )
+		IDL> src = replicate( src, 37 )
+    IDL> out_maps = foxsi_get_output_image_cube( source=src, e_min = 3, e_max=40 )
+    IDL> movie_map, out_maps
 
 
-WARNING: Run time is dependent on the size of the FOV and number of spectral intervals. At testing, a grid of 100x100 pixels will be processed at ~0.5s per spectral slice.
+While the spectra for a given pixel (x,y) may be plotted against the midpoint energy of 
+each bin with the line:
+
+		IDL> energy = average( [[out_maps.ENERGY_BIN_LOWER_BOUND_KEV],[out_maps.ENERGY_BIN_UPPER_BOUND_KEV]],2 )
+    IDL> plot, energy, out_maps.data[x,y,*]
+
+Note: The convolution currently only has one point spread function which was obtained 
+from measuring the point spread function for the on-axis position and fitting this with 
+three gaussians. (See the preamble of foxsi_get_psf_map.pro for details). Future 
+iterations of this code will include some functionality to include variance in the psf 
+for a given off axis source position and also for convolving at different spatial points 
+in the optics cross section.
+
+
+WARNING: Run time is dependent on the size of the FOV and number of spectral intervals. 
+At testing, a grid of 100x100 pixels will be processed at ~0.5s per spectral slice.
 
 
 Peripheral Functions:
-- get_source_map.pro                      (located in /response folder)
-- get_psf_array.pro                       (located in /response folder)
+- foxsi_get_default_source_cube.pro                      (located in /response folder)
+- foxsi_get_psf_map.pro                       (located in /response folder)
 - foxsi_get_effective_area.pro            (located in /response folder)
 - foxsi_make_source_structure.pro         (located in /response folder)

--- a/idl/docs/spectral_response.md
+++ b/idl/docs/spectral_response.md
@@ -19,7 +19,7 @@ elements are not included.
 Don't forget to run @foxsi-smex-setup-script before trying the routines.
 
 ;
-; Example: Get and plot the effective area for all 3 FOXSI modules.
+; Example: Plot the effective area for all 3 FOXSI modules.
 ;
 
 @foxsi-smex-setup-script			; if not already run
@@ -28,7 +28,7 @@ area = foxsi_get_effective_area()
 plot, area.energy_kev, area.eff_area_cm2, /xlog, /ylog, yrange=[1.,1.e3], $
 	thick=3, xtitle='Energy [keV]', ytitle='FOXSI effective area [cm!U-3!N]'
 oplot, area.energy_kev, area.eff_area_optic_cm2, line=1, thick=3
-al_legend, ['Single module','Three modules'], line=[0,1], thick=3
+al_legend, ['Single module','Three modules'], line=[1,0], thick=3
 
 
 ;

--- a/idl/docs/spectral_response.md
+++ b/idl/docs/spectral_response.md
@@ -1,0 +1,59 @@
+Spectral response
+=================
+
+The main function to access the effective area is `foxsi_get_effective_area`.
+It returns the effective area in cm^2 which includes the thermal blankets,
+detector efficiency, and shutters (if specified).  The area for a single optics 
+module and the area for the entire set are both returned, along with the energy 
+array at which these values are computed.
+
+If desired, the user can specify the energy array for which the effective area
+will be computed via the optional keyword ENERGY_ARR.  If no energy array is 
+input, the function will use the default energies 1-50 keV sampled at 1 keV 
+intervals.
+
+At present, only the diagonal instrument spectral response is considered. 
+Energy resolution, fluorescence, Compton scattering, and other nondiagonal 
+elements are not included.
+
+Don't forget to run @foxsi-smex-setup-script before trying the routines.
+
+;
+; Example: Get and plot the effective area for all 3 FOXSI modules.
+;
+
+@foxsi-smex-setup-script			; if not already run
+
+area = foxsi_get_effective_area()
+plot, area.energy_kev, area.eff_area_cm2, /xlog, /ylog, yrange=[1.,1.e3], $
+	thick=3, xtitle='Energy [keV]', ytitle='FOXSI effective area [cm!U-3!N]'
+oplot, area.energy_kev, area.eff_area_optic_cm2, line=1, thick=3
+al_legend, ['Single module','Three modules'], line=[0,1], thick=3
+
+
+;
+; Example: Determine the FOXSI count spectrum for a specified hard X-ray distribution.
+;
+
+@foxsi-smex-setup-script			; if not already run
+
+!p.multi=[0,1,2]
+
+; HXR source (example isothermal flare):
+t_flare  = 15			; flare temperature in MK
+em_flare = 1.d48	; flare emission measure in cm^-3
+energy_2D = get_edges( findgen(50)+1.5, /edges_2 )		; edges of energy bins
+energy = get_edges( energy_2D, /mean )
+flux = f_vth( energy_2D, [em_flare/1.d49, t_flare/11.6, 1.] )
+plot, energy, flux, /xlog, /ylog, thick=3, xtitle='Energy [keV]', $
+	ytitle='Photon flux [s!U-1!N cm!U-2!N keV!U-1!N]', $
+	title='Flare T=15 MK, EM=1.e49 cm!U-3!N'
+
+; Fold through the diagonal FOXSI response using full 3 modules.
+area = foxsi_get_effective_area( energy_arr=energy )
+counts = area.eff_area_cm2 * flux
+plot, energy, counts, /xlog, /ylog, psym=10, thick=3, xtitle='Energy [keV]', $
+	ytitle='FOXSI counts [s!U-1!N keV!U-1!N]', $
+	title='Flare T=15 MK, EM=1.e49 cm!U-3!N'
+
+!p.multi=0

--- a/idl/response/foxsi_get_output_2d_image.pro
+++ b/idl/response/foxsi_get_output_2d_image.pro
@@ -32,6 +32,7 @@
 ;;;                                accounted for
 ;;;               oversample_psf - degree of oversampling to produce a more
 ;;;                                accurate PSF. Default is 1 (no oversampling)
+;;;								quiet - Don't print out progress.
 ;;;
 ;;;COMMENTS:      -Runtime scales badly with FOV size
 ;;;               -The default source array is 
@@ -44,7 +45,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 FUNCTION foxsi_get_output_2d_image,source_map = source_map, px = pix_size, no_count_stats = no_count_stats,$
-  oversample_psf=oversample_psf
+  oversample_psf=oversample_psf, quiet=quiet
 
 IF N_ELEMENTS(SOURCE_MAP) EQ 0 THEN PRINT, 'No user input detected, using default source image'
 
@@ -65,7 +66,7 @@ dims   = SIZE(source_map.data, /DIM)
 x_size = dims[0]  ;;; Get dimensions of FOV in pixels
 y_size = dims[1]
 
-print, strcompress('Source_Array_is_'+string(x_size) $
+if not keyword_set( quiet ) then print, strcompress('Source_Array_is_'+string(x_size) $
        +'x'+string(y_size)+'_Pixels', /REMOVE_AL)
 
 ;;; Obtain psf assuming constant across FOV
@@ -101,7 +102,8 @@ FOR y = 0, y_size-1 DO BEGIN
 
        
       ;;; Progress monitor - run time is still long for large (>150'x150') FOV sizes 
-      IF x eq 0 THEN print, STRCOMPRESS("Image_Row_"+string(FIX(y+1))+"_of_"    $
+      IF x eq 0 and not keyword_set( QUIET ) THEN $
+      											 print, STRCOMPRESS("Image_Row_"+string(FIX(y+1))+"_of_"    $
                              +string(FIX(y_size))+"_completed", /REMOVE_AL)
 
    ENDFOR

--- a/idl/response/foxsi_get_output_image_cube.pro
+++ b/idl/response/foxsi_get_output_image_cube.pro
@@ -278,12 +278,15 @@ ENDIF
 
 
 for layer = 0, n_elements(source_map_spectrum) - 1 do begin
+
+	print, 'Processing map ', lower_array[layer], upper_array[layer], ' keV'
+
   ; Convert the source map from photons to counts
   this_map = source_map_spectrum[layer]
   this_map.data *= eff_area_values[layer]
 
   ; Generate the convolved image, with noise if desired
-  this_map = foxsi_get_output_2d_image(source_map=this_map,$
+  this_map = foxsi_get_output_2d_image(source_map=this_map, /quiet, $
                                        px=pix_size, no_count_stats=no_count_stats, oversample_psf=oversample_psf)
 
   ; Append the new map to the output map cube


### PR DESCRIPTION
The docs for using the spectral response and the imaging codes are now more developed, with examples.  The effective_area.md is now spectral_response.md.  The only changes to the codes themselves are light touches to change amount of text printed out in each run.

Addresses Issue [26](https://github.com/foxsi/foxsi-smex/issues/26).
