### PR TITLE
Critical fix to Python calculation of response

### DIFF
--- a/pyfoxsi/src/pyfoxsi/response/response.py
+++ b/pyfoxsi/src/pyfoxsi/response/response.py
@@ -110,9 +110,9 @@ class Response(object):
             print(material.name)
             if material.name == pyfoxsi.detector_material:
                 # if it is the detector than we want the absorption
-                factor *= factor * material.absorption(energies)
+                factor *= material.absorption(energies)
             else:
-                factor *= factor * material.transmission(energies)
+                factor *= material.transmission(energies)
         self.effective_area['factor'] = factor
         self.effective_area['total'] = factor * self.optics_effective_area['total']
         self.effective_area['module'] = factor * self.optics_effective_area['module']


### PR DESCRIPTION
On the Python side, there's a critical bug with the multiplication of transmission and absorption coefficients where `factor` is squared before tacking on the next coefficient.  In the current configuration, that simply means the Mylar correction is getting counted twice, but the situation would have exponentiated as more materials were added to the optical path.

@ehsteve Review and merge ASAP;
