### PR TITLE
Critical fix for incorrect detector thickness

### DIFF
--- a/idl/foxsi-smex-setup-script.pro
+++ b/idl/foxsi-smex-setup-script.pro
@@ -19,7 +19,7 @@ foxsi_launch_date = '2020/06/01'
 foxsi_focal_length = 15
 
 foxsi_shutters_thickness_mm = [0, 2.4, 4.8]
-foxsi_detector_thickness_mm = 0.500
+foxsi_detector_thickness_mm = 1.0
 ; the blankets are assumed to be made of mylar
 foxsi_blanket_thickness_mm = 0.5
 

--- a/pyfoxsi/src/pyfoxsi/__init__.py
+++ b/pyfoxsi/src/pyfoxsi/__init__.py
@@ -10,7 +10,7 @@ detector_material = 'cdte'
 launch_date = datetime(2020, 06, 01)
 
 shutters_thickness = [0, 1.0, 1.5] * u.mm
-detector_thickness = 500 * u.micron
+detector_thickness = 1.0 * u.mm
 blanket_thickness = 0.5 * u.mm
 
 focal_length = 15 * u.m


### PR DESCRIPTION
The thickness of the HEXITEC CdTe detectors is not correct in the software.  They are 1 mm thick, not 0.5 mm thick.  The efficiency starts to deviate at ~40 keV, but it probably won't have noticeable impact until ~50 keV.

Review and merge as soon as possible
