### PR TITLE
`foxsi_get_instrument_background.pro` to obtain the estimate of instrument background

### DIFF
--- a/idl/instr/foxsi_get_instrument_background.pro
+++ b/idl/instr/foxsi_get_instrument_background.pro
@@ -1,14 +1,20 @@
 ;+
 ; NAME : foxsi_get_instrument_background
 ;
-; PURPOSE : Returns the current best estimate for the instrument_background (defaults to entire instrument)
+; PURPOSE : Returns the current best estimate for the instrument background (both telescopes).
+;   See https://docs.google.com/document/d/1oMd9dJ0RoMMoT86fpZeK6b5eztfPzlg_bO47GiXqx7s/edit?usp=sharing
+;   for a detailed write-up.
 ;
 ; SYNTAX : bkg = foxsi_get_instrument_background()
 ;
 ; INPUTS : None
 ;
 ; Optional Inputs :
-;			energy_arr - array of energies in keV (default is 1-keV binning from 0 to 60 keV)
+;			energy_arr - for the returned spectrum, use the energies in this array (in keV)
+;			                 rather than the default energies (1-keV steps from 0 to 60 keV)
+;
+; Optional Outputs :
+;			energy_arr - the energy array used
 ;
 ; KEYWORDS :
 ;			in_hpd - if set, scale background to only within the nominal HPD (25")
@@ -23,9 +29,7 @@ FUNCTION foxsi_get_instrument_background, ENERGY_ARR = energy_arr, IN_HPD = in_h
 
     default, energy_arr, findgen(60)
 
-    ; This expression includes an additional factor of 2 to account for the increased background
-    ; at 28.5-deg inclination compared to 6-deg inclination
-    result = 2. * 2. * energy_arr ^ (-0.8) * exp(-energy_arr / 30.)
+    result = 2. * energy_arr ^ (-0.8) * exp(-energy_arr / 30.)
 
     IF keyword_set(in_hpd) THEN result *= !pi / 4. * 25. ^ 2 / (9. * 60) ^ 2
 

--- a/idl/instr/foxsi_get_instrument_background.pro
+++ b/idl/instr/foxsi_get_instrument_background.pro
@@ -8,7 +8,7 @@
 ; INPUTS : None
 ;
 ; Optional Inputs :
-;			energy_arr - array of energies in keV 
+;			energy_arr - array of energies in keV (default is 1-keV binning from 0 to 60 keV)
 ;
 ; KEYWORDS :
 ;			in_hpd - if set, scale background to only within the nominal HPD (25")
@@ -21,12 +21,11 @@
 
 FUNCTION foxsi_get_instrument_background, ENERGY_ARR = energy_arr, IN_HPD = in_hpd
 
-    IF NOT keyword_set(energy_arr) THEN energy_keV = findgen(60) ELSE $
-        energy_keV = energy_arr
+    default, energy_arr, findgen(60)
 
     ; This expression includes an additional factor of 2 to account for the increased background
     ; at 28.5-deg inclination compared to 6-deg inclination
-    result = 2. * 2. * energy_keV ^ (-0.8) * exp(-energy_keV / 30.)
+    result = 2. * 2. * energy_arr ^ (-0.8) * exp(-energy_arr / 30.)
 
     IF keyword_set(in_hpd) THEN result *= !pi / 4. * 25. ^ 2 / (9. * 60) ^ 2
 

--- a/idl/instr/foxsi_get_instrument_background.pro
+++ b/idl/instr/foxsi_get_instrument_background.pro
@@ -1,0 +1,31 @@
+;+
+; NAME : foxsi_get_instrument_background
+;
+; PURPOSE : Returns the current best estimate for the instrument_background (defaults to entire instrument)
+;
+; SYNTAX : bkg = foxsi_get_instrument_background()
+;
+; INPUTS : None
+;
+; Optional Inputs :
+;			energy_arr - array of energies in keV 
+;
+; KEYWORDS :
+;			in_hpd - if set, scale background to only within the nominal HPD (25")
+;
+; RETURNS : 
+;			background in units of counts/s/keV
+;
+; EXAMPLES : None
+;
+
+FUNCTION foxsi_get_instrument_background, ENERGY_ARR = energy_arr, IN_HPD = in_hpd
+
+    IF NOT keyword_set(energy_arr) THEN energy_keV = findgen(60) ELSE $
+        energy_keV = energy_arr
+
+    result = 2. * energy_keV ^ (-0.8) * exp(-energy_keV / 30.)
+    IF keyword_set(in_hpd) THEN result *= !pi / 4. * 25. ^ 2 / (9. * 60) ^ 2
+
+    RETURN, result
+END

--- a/idl/instr/foxsi_get_instrument_background.pro
+++ b/idl/instr/foxsi_get_instrument_background.pro
@@ -24,7 +24,10 @@ FUNCTION foxsi_get_instrument_background, ENERGY_ARR = energy_arr, IN_HPD = in_h
     IF NOT keyword_set(energy_arr) THEN energy_keV = findgen(60) ELSE $
         energy_keV = energy_arr
 
-    result = 2. * energy_keV ^ (-0.8) * exp(-energy_keV / 30.)
+    ; This expression includes an additional factor of 2 to account for the increased background
+    ; at 28.5-deg inclination compared to 6-deg inclination
+    result = 2. * 2. * energy_keV ^ (-0.8) * exp(-energy_keV / 30.)
+
     IF keyword_set(in_hpd) THEN result *= !pi / 4. * 25. ^ 2 / (9. * 60) ^ 2
 
     RETURN, result


### PR DESCRIPTION
Added a function (only on the IDL side) to obtain the estimate of instrument background (in units of counts/s/keV) for the entire instrument (i.e., both telescopes).  The optional keyword `in_hpd` provides a convenient scaling of the background to only the HPD (assuming uniform background) for the purposes of point sources.
